### PR TITLE
Add support for formatting YAML files during lint-staged.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 work/
 package-lock.json
 .DS_Store
+.idea/

--- a/config/lint-staged.js
+++ b/config/lint-staged.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.{ts,tsx,js,jsx,json,css,md}': ['prettier --write'],
+  '*.{ts,tsx,js,jsx,json,css,md,yaml,yml}': ['prettier --write'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/typescript-tools",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "main": "./index.js",
   "repository": "https://github.com/jupiterone/typescript-tools",
   "author": "Development <development@jupiterone.com>",


### PR DESCRIPTION
If there are YAML files added to a repo, or generated by a script and added as part of a commit hook, this change includes those files when running `prettier -w`.